### PR TITLE
Fix in-page resource links (Contents → resource cards)

### DIFF
--- a/docs/generate_docs_gen10.py
+++ b/docs/generate_docs_gen10.py
@@ -534,9 +534,10 @@ def format_resource_markdown(resource: Dict[str, Any], item_code: str) -> str:
     md = ""
 
     # --- Header first (H3 so page title stays dominant) ---
+    anchor = slugify(f"{item_code} {title}")
+
     md += (
-        "### "
-        f'<span class="resource-header">'
+        f'### <span class="resource-header" id="{anchor}">'
         f'<span class="resource-id">{item_code}</span>'
         f'<span class="resource-title">{title}</span>'
         f"</span>\n\n"

--- a/docs/generate_docs_gen9.py
+++ b/docs/generate_docs_gen9.py
@@ -525,9 +525,10 @@ def format_resource_markdown(resource: Dict[str, Any], item_code: str) -> str:
     md = ""
 
     # --- Header first (H3 so page title stays dominant) ---
+    anchor = slugify(f"{item_code} {title}")
+
     md += (
-        "### "
-        f'<span class="resource-header">'
+        f'### <span class="resource-header" id="{anchor}">'
         f'<span class="resource-id">{item_code}</span>'
         f'<span class="resource-title">{title}</span>'
         f"</span>\n\n"

--- a/docs/pages/030300_en.md
+++ b/docs/pages/030300_en.md
@@ -28,7 +28,7 @@ System state, Darcy’s law applications, groundwater flow equation, analytical 
 | **03-03-002** | [Analytical solutions for 1D flow, Unconfined and Confined aquifer bounded by two specified head boundaries](#03-03-002-analytical-solutions-for-1d-flow-unconfined-and-confined-aquifer-bounded-by-two-specified-head-boundaries) |
 | **03-03-003** | [Analytical solution for 1D unconfined flow with one no-flow boundary and one specified head/head-dependent boundary](#03-03-003-analytical-solution-for-1d-unconfined-flow-with-one-no-flow-boundary-and-one-specified-head-head-dependent-boundary) |
 
-### <span class="resource-header"><span class="resource-id">03-03-001</span><span class="resource-title">Analytical solution for 1D unconfined flow with two specified head boundaries</span></span>
+### <span class="resource-header" id="03-03-001-analytical-solution-for-1d-unconfined-flow-with-two-specified-head-boundaries"><span class="resource-id">03-03-001</span><span class="resource-title">Analytical solution for 1D unconfined flow with two specified head boundaries</span></span>
 
 **Type:** Streamlit app | **Time:** 5–15 min
 
@@ -73,7 +73,7 @@ Users can interactively explore the influence of recharge, hydraulic conductivit
 
 ---
 
-### <span class="resource-header"><span class="resource-id">03-03-002</span><span class="resource-title">Analytical solutions for 1D flow, Unconfined and Confined aquifer bounded by two specified head boundaries</span></span>
+### <span class="resource-header" id="03-03-002-analytical-solutions-for-1d-flow-unconfined-and-confined-aquifer-bounded-by-two-specified-head-boundaries"><span class="resource-id">03-03-002</span><span class="resource-title">Analytical solutions for 1D flow, Unconfined and Confined aquifer bounded by two specified head boundaries</span></span>
 
 **Type:** Streamlit app | **Time:** 5–15 min
 
@@ -118,7 +118,7 @@ Users can interactively adjust hydraulic conductivity, aquifer length, and bound
 
 ---
 
-### <span class="resource-header"><span class="resource-id">03-03-003</span><span class="resource-title">Analytical solution for 1D unconfined flow with one no-flow boundary and one specified head/head-dependent boundary</span></span>
+### <span class="resource-header" id="03-03-003-analytical-solution-for-1d-unconfined-flow-with-one-no-flow-boundary-and-one-specified-head-head-dependent-boundary"><span class="resource-id">03-03-003</span><span class="resource-title">Analytical solution for 1D unconfined flow with one no-flow boundary and one specified head/head-dependent boundary</span></span>
 
 **Type:** Streamlit app | **Time:** 5–15 min
 

--- a/docs/pages/040100_en.md
+++ b/docs/pages/040100_en.md
@@ -27,7 +27,7 @@ Basic physical characteristics influencing unsaturated flow: texture, structure,
 | **04-01-001** | [Soil Texture Triangle](#04-01-001-soil-texture-triangle) |
 | **04-01-002** | [Soil Texture Classes](#04-01-002-soil-texture-classes) |
 
-### <span class="resource-header"><span class="resource-id">04-01-001</span><span class="resource-title">Soil Texture Triangle</span></span>
+### <span class="resource-header" id="04-01-001-soil-texture-triangle"><span class="resource-id">04-01-001</span><span class="resource-title">Soil Texture Triangle</span></span>
 
 **Type:** Jupyter Notebook | **Time:** 5–15 min
 
@@ -65,7 +65,7 @@ This Notebook illustrates how the percentages of the particle-size classes sand,
 
 ---
 
-### <span class="resource-header"><span class="resource-id">04-01-002</span><span class="resource-title">Soil Texture Classes</span></span>
+### <span class="resource-header" id="04-01-002-soil-texture-classes"><span class="resource-id">04-01-002</span><span class="resource-title">Soil Texture Classes</span></span>
 
 **Type:** Streamlit app | **Time:** 5–15 min
 

--- a/docs/pages/050600_en.md
+++ b/docs/pages/050600_en.md
@@ -26,7 +26,7 @@ Coupling of chemical reactions with physical transport processes; conceptual and
 | :--- | :--- |
 | **05-06-001** | [Mass balance for a decay chain - Decay of Species A to B and species B to C](#05-06-001-mass-balance-for-a-decay-chain-decay-of-species-a-to-b-and-species-b-to-c) |
 
-### <span class="resource-header"><span class="resource-id">05-06-001</span><span class="resource-title">Mass balance for a decay chain - Decay of Species A to B and species B to C</span></span>
+### <span class="resource-header" id="05-06-001-mass-balance-for-a-decay-chain-decay-of-species-a-to-b-and-species-b-to-c"><span class="resource-id">05-06-001</span><span class="resource-title">Mass balance for a decay chain - Decay of Species A to B and species B to C</span></span>
 
 **Type:** Streamlit app | **Time:** 5–15 min
 

--- a/docs/pages/060400_en.md
+++ b/docs/pages/060400_en.md
@@ -28,7 +28,7 @@ Pumping tests, recovery tests, step-drawdown tests, slug tests, and other field-
 | **06-04-002** | [Slugtest Evaluation](#06-04-002-slugtest-evaluation) |
 | **06-04-003** | [The Theis solution for pumping test evaluation](#06-04-003-the-theis-solution-for-pumping-test-evaluation) |
 
-### <span class="resource-header"><span class="resource-id">06-04-001</span><span class="resource-title">The Pumping Test Module</span></span>
+### <span class="resource-header" id="06-04-001-the-pumping-test-module"><span class="resource-id">06-04-001</span><span class="resource-title">The Pumping Test Module</span></span>
 
 **Type:** Streamlit app | **Time:** 2 hours
 
@@ -118,7 +118,7 @@ Overview of the module: This module combines theoretical explanations with inter
 
 ---
 
-### <span class="resource-header"><span class="resource-id">06-04-002</span><span class="resource-title">Slugtest Evaluation</span></span>
+### <span class="resource-header" id="06-04-002-slugtest-evaluation"><span class="resource-id">06-04-002</span><span class="resource-title">Slugtest Evaluation</span></span>
 
 **Type:** Streamlit app | **Time:** 15–30 minutes
 
@@ -187,7 +187,7 @@ Users can work with predefined field datasets (Varnum, Sweden; Viterbo, Italy), 
 
 ---
 
-### <span class="resource-header"><span class="resource-id">06-04-003</span><span class="resource-title">The Theis solution for pumping test evaluation</span></span>
+### <span class="resource-header" id="06-04-003-the-theis-solution-for-pumping-test-evaluation"><span class="resource-id">06-04-003</span><span class="resource-title">The Theis solution for pumping test evaluation</span></span>
 
 **Type:** Streamlit app | **Time:** 30–45 minutes
 

--- a/docs/pages/080100_en.md
+++ b/docs/pages/080100_en.md
@@ -26,7 +26,7 @@ Model domain, boundaries, sources/sinks, model simplifications. Main focus is th
 | :--- | :--- |
 | **08-01-001** | [Introduction in Boundary Conditions](#08-01-001-introduction-in-boundary-conditions) |
 
-### <span class="resource-header"><span class="resource-id">08-01-001</span><span class="resource-title">Introduction in Boundary Conditions</span></span>
+### <span class="resource-header" id="08-01-001-introduction-in-boundary-conditions"><span class="resource-id">08-01-001</span><span class="resource-title">Introduction in Boundary Conditions</span></span>
 
 **Type:** Streamlit app | **Time:** 30–45 minutes
 

--- a/docs/pages/080200_en.md
+++ b/docs/pages/080200_en.md
@@ -26,7 +26,7 @@ Spatial/temporal discretization, stability, solution algorithms, convergence.
 | :--- | :--- |
 | **08-02-001** | [Finite Difference Numerical Scheme](#08-02-001-finite-difference-numerical-scheme) |
 
-### <span class="resource-header"><span class="resource-id">08-02-001</span><span class="resource-title">Finite Difference Numerical Scheme</span></span>
+### <span class="resource-header" id="08-02-001-finite-difference-numerical-scheme"><span class="resource-id">08-02-001</span><span class="resource-title">Finite Difference Numerical Scheme</span></span>
 
 **Type:** Streamlit app | **Time:** 15–30 minutes
 

--- a/docs/pages/080700_en.md
+++ b/docs/pages/080700_en.md
@@ -27,7 +27,7 @@ Techniques for adjusting model parameters to match observations, including inver
 | **08-07-001** | [Analytical solution for 1D unconfined flow with two specified head boundaries - Understanding model calibration](#08-07-001-analytical-solution-for-1d-unconfined-flow-with-two-specified-head-boundaries-understanding-model-calibration) |
 | **08-07-002** | [Analytical solution for 1D unconfined flow with one no-flow boundary and one specified head/head-dependent boundary - Understanding model calibration](#08-07-002-analytical-solution-for-1d-unconfined-flow-with-one-no-flow-boundary-and-one-specified-head-head-dependent-boundary-understanding-model-calibration) |
 
-### <span class="resource-header"><span class="resource-id">08-07-001</span><span class="resource-title">Analytical solution for 1D unconfined flow with two specified head boundaries - Understanding model calibration</span></span>
+### <span class="resource-header" id="08-07-001-analytical-solution-for-1d-unconfined-flow-with-two-specified-head-boundaries-understanding-model-calibration"><span class="resource-id">08-07-001</span><span class="resource-title">Analytical solution for 1D unconfined flow with two specified head boundaries - Understanding model calibration</span></span>
 
 **Type:** Streamlit app | **Time:** 15–30 minutes
 
@@ -94,7 +94,7 @@ To mimic real calibration workflows, the app can generate synthetic “measureme
 
 ---
 
-### <span class="resource-header"><span class="resource-id">08-07-002</span><span class="resource-title">Analytical solution for 1D unconfined flow with one no-flow boundary and one specified head/head-dependent boundary - Understanding model calibration</span></span>
+### <span class="resource-header" id="08-07-002-analytical-solution-for-1d-unconfined-flow-with-one-no-flow-boundary-and-one-specified-head-head-dependent-boundary-understanding-model-calibration"><span class="resource-id">08-07-002</span><span class="resource-title">Analytical solution for 1D unconfined flow with one no-flow boundary and one specified head/head-dependent boundary - Understanding model calibration</span></span>
 
 **Type:** Streamlit app | **Time:** 15–30 minutes
 


### PR DESCRIPTION
Restored working in-page navigation for the Resources → Contents table.

Added explicit anchor IDs to card-style resource headers so TOC links scroll correctly.